### PR TITLE
fix: Support big integers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,8 @@ extern crate alloc;
 
 use core::cmp::Ordering;
 
+use alloc::{vec, string::String};
+
 #[cfg(feature = "std")]
 use std::ffi::{CStr, OsStr};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ extern crate alloc;
 
 use core::cmp::Ordering;
 
-use alloc::{vec, string::String};
+use alloc::vec;
 
 #[cfg(feature = "std")]
 use std::ffi::{CStr, OsStr};
@@ -177,11 +177,11 @@ pub fn compare_str<A: AsRef<str>, B: AsRef<str>>(a: A, b: B) -> Ordering {
                     }
                 }
                 _ => {
-                    let str_a = da.into_iter().collect::<String>();
-                    let str_b = db.into_iter().collect::<String>();
-                    if let Some(ordering) = str_a.partial_cmp(&str_b) {
-                        if ordering != Ordering::Equal {
-                            return ordering;
+                    for i in 0..da.len() {
+                        if let Some(ordering) = da[i].partial_cmp(&db[i]) {
+                            if ordering != Ordering::Equal {
+                                return ordering;
+                            }
                         }
                     }
                 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -136,11 +136,20 @@ fn compare_lv5_3() {
 #[test]
 fn compare_lv6_1() {
     assert_eq!(Ordering::Less, alphanumeric_sort::compare_str("1", "1a"));
+    assert_eq!(Ordering::Less, alphanumeric_sort::compare_str("1", "11"));
+    assert_eq!(Ordering::Less, alphanumeric_sort::compare_str("1", "01"));
+    assert_eq!(Ordering::Less, alphanumeric_sort::compare_str("0", "00"));
 }
 
 #[test]
 fn compare_lv6_2() {
     assert_eq!(Ordering::Greater, alphanumeric_sort::compare_str("1a", "1"));
+}
+
+#[test]
+fn compare_lv6_3() {
+    assert_eq!(Ordering::Greater, alphanumeric_sort::compare_str("01", "00"));
+    assert_eq!(Ordering::Greater, alphanumeric_sort::compare_str("1", "0000"));
 }
 
 #[test]
@@ -171,6 +180,25 @@ fn compare_lv9_1() {
 #[test]
 fn compare_lv9_2() {
     assert_eq!(Ordering::Greater, alphanumeric_sort::compare_str("01", "1"));
+}
+
+#[test]
+fn compare_big_numbers_1() {
+    assert_eq!(
+        alphanumeric_sort::compare_str(
+            "234784353456723654872364354374658736457364",
+            "234784353456723654872364354374658736457365",
+        ),
+        Ordering::Less
+    );
+}
+
+#[test]
+fn compare_big_numbers_2() {
+    assert_eq!(alphanumeric_sort::compare_str(
+        "23478435345672365487236435437465873645736452658734658734653645872542736437465365487326548734658736457265345736458733",
+        "23478435345672365487236435437465873645736452658734658734653645872542736437465365487326548734658736457265345736458730",
+    ), Ordering::Greater);
 }
 
 #[test]


### PR DESCRIPTION
fix Issue https://github.com/magiclen/alphanumeric-sort/issues/4
## How
Use `vec` to store number, instead of `f64`
## Benchmark
The original
```shell
test compare_path           ... bench:       4,235 ns/iter (+/- 1,908)
test sort_path_slice        ... bench:       2,313 ns/iter (+/- 1,398)
test sort_slice_by_path_key ... bench:       2,952 ns/iter (+/- 5,800)
```
Now
```shell
test compare_path           ... bench:      11,149 ns/iter (+/- 5,920)
test sort_path_slice        ... bench:       5,798 ns/iter (+/- 3,882)
test sort_slice_by_path_key ... bench:       5,875 ns/iter (+/- 3,897)

```